### PR TITLE
Fixed FAQ link

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -126,7 +126,5 @@ Ask the NodeBB Community
 ------------------------
 
 Having trouble installing NodeBB? Or did something break? Don't hesitate
-to 
-        <a href="https://community.nodebb.org/register" target="_blank">join our forum</a>
-and ask for help.
+to [join our forum](https://community.nodebb.org/register) and ask for help.
 Hopefully one day you'll be able to help others too :)


### PR DESCRIPTION
Fixed FAQ link: `https://community.nodebb.org/`register from `..community.nodebb.org/` to allow the proper web page to be opened and not error out. Should also open in new tab, tried to mix HTML and MD so that it does open in a new tab but I do not think it worked, regardless the correct link does work but does not open new tab. 