### PR TITLE
module definition in plugin.json

### DIFF
--- a/docs/development/plugins/libraries.md
+++ b/docs/development/plugins/libraries.md
@@ -21,7 +21,7 @@ In NodeBB, you'll want to use the `modules` property in `plugin.json` to properl
 {
 	...
 	"modules": {
-		"jquery": "/path/to/jquery.js"
+		"jquery.js": "/path/to/jquery.js"
 	},
 	...
 }


### PR DESCRIPTION
Must have `.js` extension to be loaded successfully, is it a bug in nodebb or in the docs ?