### PR TITLE
Fix broken link on debian install doc

### DIFF
--- a/src/docs/installing/os/debian.md
+++ b/src/docs/installing/os/debian.md
@@ -169,7 +169,7 @@ $ ./nodebb start
 **Note:** If you NodeBB or your server crash, your NodeBB instance will
 not reboot (snap), this is why you should take a look at the other way
 to start your NodeBB instance with helper programs such as `supervisor`
-and `forever`, just take a look [here](../../running/index).
+and `forever`, just take a look [here](../../configuring/running).
 
 Extras, tips and Advice
 -----------------------


### PR DESCRIPTION
This PR fixes a broken link on Debian installation docs on step "Installing nodebb" : https://docs.nodebb.org/installing/os/debian/