### PR TITLE
Add the build step for plugin development

### DIFF
--- a/src/docs/development/plugins/index.md
+++ b/src/docs/development/plugins/index.md
@@ -243,6 +243,10 @@ Then in the source folder were nodebb is installed.
 ```
 npm link my-plugin
 ```
+You will then need to build nodebb:
+```
+./nodebb build
+```
 
 Your plugin should now be available in admin to be activated.
 


### PR DESCRIPTION
This step was missing in the doc for plugin development.
Also I would strongly suggest to talk about https://github.com/NodeBB/nodebb-plugin-quickstart since at least briefly since this repo helps getting started quickly. Happy to do a PR for it, lmk where you think is the best place to talk about it.