### PR TITLE
Correct database config string in fedora.md

### DIFF
--- a/src/docs/installing/os/fedora.md
+++ b/src/docs/installing/os/fedora.md
@@ -108,7 +108,7 @@ cd /opt/nodebb
 sudo -u nodebb ./nodebb setup
 ```
 
-The wizards will ask what database to use, make sure you specify `postgresql` and then use the same information as used above when the database was created.
+The wizards will ask what database to use, make sure you specify `postgres` and then use the same information as used above when the database was created.
 
 Lastly, we run the forum, again as the nodebb user.
 


### PR DESCRIPTION
You can see in install/databases.js that it's supposed to be `postgres` not `postgresql`