### PR TITLE
Fix typo

### DIFF
--- a/src/templates/installing/os/template.md
+++ b/src/templates/installing/os/template.md
@@ -11,7 +11,7 @@ This installation guide is optimized for
 
 ## Installing Node.js
 
-Naturally, NodeBB is driven by Node.js, and so it needs to be installed. Node.js is a rapidly evolving platform and so installation of the current LTS version of Node.js is recommended to make future updates seemless. The [Node.js LTS Plan](https://github.com/nodejs/LTS) details the LTS release schedule including projected end-of-life.
+Naturally, NodeBB is driven by Node.js, and so it needs to be installed. Node.js is a rapidly evolving platform and so installation of the current LTS version of Node.js is recommended to make future updates seamless. The [Node.js LTS Plan](https://github.com/nodejs/LTS) details the LTS release schedule including projected end-of-life.
 
 {{node.install}}
 


### PR DESCRIPTION
Noticed a small typo while using the docs on a page generated with [`src/templates/installing/os/template.md`](/NodeBB/docs/blob/master/src/templates/installing/os/template.md) and figured I'd make the minor correction. Thanks!