### PR TITLE
Update node.js proxy docs

### DIFF
--- a/src/docs/configuring/proxies/node.md
+++ b/src/docs/configuring/proxies/node.md
@@ -1,123 +1,150 @@
 Configuring a node.js reverse proxy
-============================
+===================================
 
-In this tutorial we will create a reverse proxy https server complete
-with proxy rules, websockets, and TLS. This will allow multiple node
-applications to share the same domain, so that you can run NodeBB on a
-specific path (IE /forum) and another node application on another path.
+In this tutorial we will create a simple reverse proxy https server 
+that proxies requests to the /forum path of an https server to
+the /forum path of a nodebb server running at http://localhost:4567
 
-## Requirements
+### Requirements
 
--   NodeBB installation
--   Node.js v5.0
--   The following npm packages installed using the command: npm install PACKAGE\_NAME\_HERE --save
-    -   http-proxy-rules
-    -   express
-    -   http-proxy
+- NodeBB installation
+- Node.js v5.0
+- The following npm packages installed using the command: npm install PACKAGE\_NAME\_HERE --save
+  - express 
+  - http-proxy-middleware or https-proxy
 
-### Include packages
+### 
 
-Create a node.js app with the following code
+### Example server source code
 
-``` js
-var https = require('https');
-var httpProxy = require('http-proxy');
-var express = require('express');
-var HttpProxyRules = require('http-proxy-rules');
+Here is the complete server source code. You can run it using something like ```node server.js```. You will need to start nodebb separately, but only after you've modified config.json - see below.
+
+```js
+const express = require("express");
+const fs = require("fs");
+const https = require("https");
+
+const {createProxyMiddleware} = require("http-proxy-middleware");
+
+function main() {
+
+    const app = express();
+
+    // This is the line that sets up the actual proxy.
+    // Note: the {xfwd: true} option here is very important!
+    app.use("/forum", createProxyMiddleware("http://localhost:4567", {
+        xfwd: true
+    }));
+
+    // Otherwise not found.
+    app.use((req, res) => {
+        res.statusCode = 404;
+        res.end("Not found");
+    });
+
+    const serverOpts = {
+      key: fs.readFileSync("/etc/letsencrypt/live/example.com/privkey.pem"),
+      cert: fs.readFileSync("/etc/letsencrypt/live/example.com/fullchain.pem")
+    };
+
+    https.createServer(serverOpts, app).listen(443);
+}
+
+main();
 ```
 
-#### Define proxy rules and create proxy
+### Modifying NodeBB config.json
 
-Change these proxy rules to suit your needs. These rules will determine
-where traffic is proxied to based on the url path. In this example we
-assume you have an instance of NodeBB running on the default port
+You will also need to modify the config.json file in the nodebb directory. The following  is just an example, your config will differ depending on DB used, "secret", "url" etc.
 
-``` js
-var proxyRules = new HttpProxyRules({
-    rules: {
-        '.*/docs': 'http://localhost:8081', // Rule (1) docs, about, etc
-        '.*/docs/*': 'http://localhost:8081',
-        '.*/about': 'http://localhost:8081',
-        '.*/press': 'http://localhost:8081',
-        '.*/jobs': 'http://localhost:8081',
-        '.*/developers': 'http://localhost:8081',
+The important thing to get right here is the "url" property. This should be the url of the forum at your server (including path), and is the url users will type into their browsers to visit your forum.
 
-        '.*/forum': 'http://localhost:4567/forum', // Rule (2) forums
-        '.*/forum/*': 'http://localhost:4567/forum', 
-        '/forum/*': 'http://localhost:4567/forum',
-        './forum/*': 'http://localhost:4567/forum',
-        '/forum': 'http://localhost:4567/forum' 
-    },
-    default: 'http://localhost:8081' // default target, will be landing page
-});
-var proxy = httpProxy.createProxy();
+```json
+{
+    "url": "https://example.com/forum",
+    "secret": "...etc...",
+    "database": "mongo",
+    "mongo": {
+        "host": "127.0.0.1",
+        "port": 27017,
+        "username": "...etc...",
+        "password": "...etc...",
+        "database": "nodebb",
+        "uri": "mongodb://localhost:27017/nodebb"
+    }
+}
 ```
 
-#### Change url in NodeBB config.json
+### Proxying without express
 
-Suffix the path you set in the proxy rules onto the default NodeBB url
-in the config.json file in your NodeBB directory. In this example, the
-path was /forum, so the URL becomes: .. code:: javascript
-<http://localhost:4567/forum>
+If you are not using express, it's also possible to use the http-proxy module alone.
 
-#### Create the web server and call the proxy
+Here is an example of proxying without express:
 
-First create the express.js app
+```js
+const https = require("https");
+const httpProxy = require("http-proxy"); 
+const fs = require("fs");
 
-``` js
-var express = require('express');
-var bodyParser = require('body-parser')
-var mainapp = express();
-mainapp.use(function(req,res,next){
-    try{
-        if (req.url.substr(0, 18).indexOf("socket.io")>-1){
-            //console.log("SOCKET.IO", req.url)
-            return proxy.web(req, res, { target: 'wss://localhost:4567', ws: true }, function(e) { 
-            //console.log('PROXY ERR',e)
+function main() {
+
+    const serverOpts = {
+      key: fs.readFileSync("/etc/letsencrypt/live/example.com/privkey.pem"),
+      cert: fs.readFileSync("/etc/letsencrypt/live/example.com/fullchain.pem")
+    };
+
+    proxy = httpProxy.createProxyServer();
+
+    const server = https.createServer(serverOpts, (req, res) => {
+        if(req.url === "/forum" || req.url.startsWith("/forum/")) {
+            // Note: the {xfwd: true} option here is very important!
+            // Also, make sure to provide an error handler or you'll get an unhandled exception
+            return proxy.web(req, res, {
+                    target: "http://localhost:4567",
+                    xfwd: true
+                }, (err) => {
+                console.log("### Proxy error:", err);
             });
-        } else {
-            var target = proxyRules.match(req);
-            if (target) {
-                //console.log("TARGET", target, req.url)
-                return proxy.web(req, res, {
-                    target: target
-                }, function(e) { 
-                //console.log('PROXY ERR',e)
-                });
-            } else {
-                res.sendStatus(404);
-            }
         }
-    } catch(e){
-        res.sendStatus(500);
-    }
-});
-mainapp.use(bodyParser.json());
-mainapp.use(bodyParser.urlencoded({ extended: false }));
+        res.statusCode = 404;
+        res.end("### Not found");
+
+    });
+
+    server.listen(443);
+}
+
+main();
 ```
 
-Then put the code to start the web server, and put your HTTPS options in
-the options variable. (see node docs for more info about HTTPS)
+### Trouble shooting
 
-Change the port (4433) to your port.
+The problem you're mostly to run into is "Invalid CSRF Token" which appears to be related to session cookies.
 
-``` js
-var options = {/*Put your TLS options here.*/};
+The primary causes of this seem to be:
 
-var mainserver = https.createServer(options, mainapp);
-mainserver.listen(4433);
-mainserver.on('listening', onListening);
-mainserver.on('error', function (error, req, res) {
-    var json;
-    console.log('proxy error', error);
-    if (!res.headersSent) {
-    res.writeHead(500, { 'content-type': 'application/json' });
-    }
+* Incorrect "url" in config.json - double check your config.json
 
-    json = { error: 'proxy_error', reason: error.message };
-    res.end(JSON.stringify(json));
-});
+* Missing X-Forward headers - make sure you've got the {xfwd: true} option set in your proxy.
+
+* Problems with cookieDomain - search nodebb forums!
+
+One thing you can try that helped me out is comparing the success or otherwise of network connections (you can view these in the browser F12 debug console) when visiting the nodebb server directly vs over a proxy.
+
+To run nodebb directly over https, you'll need to add the following lines to config.json:
+
+```json
+    "ssl": {
+        "key": "/etc/letsencrypt/live/example.com/privkey.pem",
+        "cert": "/etc/letsencrypt/live/example.com/fullchain.pem"
+    },
+    "port": 443
 ```
 
-Thats it. Start up the proxy server, start up NodeBB, and start up your
-second server on port 8081 (or whichever port you chose)
+You will probably also need to add the port to your "url", eg:
+
+```json
+    "url": "https://example.com:443/forum"
+```
+
+Good luck!


### PR DESCRIPTION
Hi,

Here's some simplified node.js proxy docs, mainly in the form of some single file demos to keep things simple.

There are a few things I'm a bit confused by though, I did not end up using any of the websocket related options from the original code, and everything seems to work fine without them. I've compared the network connections made via proxy vs directly over https using the firefox F12 debugger, and they appear to be the same, the GET /forum/socket.io results in a '101' socket upgrade response, and the SEND /forum/socket.io results in a '200' XHR response on both so AFAICT the websocket stuff is working well.

I've given NodeBB a pretty good thrashing by now, including rebuilding/restarting the forum 'live' online, installing plugins, sending emails etc without any apparent problems.

Bye!
Mark
