### PR TITLE
Add official search plugin to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ markdown_extensions:
     - fenced_code
     - tables
 plugins:
+    - search
     - social
 nav:
     - 'index.md'


### PR DESCRIPTION
Material for MkDocs officially provides a (built-in) plugin which adds full-text search to documentation sites (https://squidfunk.github.io/mkdocs-material/plugins/search/). It works with client-side JavaScript and it's really useful, makes it a breeze to comb trough large wikis like this looking for specific information.

I tested it locally for the NodeBB Docs, and can confirm it works without issues, so, this pull request enables it for the online version of the site.